### PR TITLE
remove bitwise from quantifiers tests

### DIFF
--- a/test/regress/regress3/bv_to_int_check_bvsge_bvashr0_4bit.smt2.minimized.smt2
+++ b/test/regress/regress3/bv_to_int_check_bvsge_bvashr0_4bit.smt2.minimized.smt2
@@ -1,5 +1,4 @@
 ; COMMAND-LINE:  --solve-bv-as-int=sum  --no-check-models
-; COMMAND-LINE:  --solve-bv-as-int=bitwise  --no-check-models
 ; EXPECT: sat
 (set-logic BV)
 (declare-fun s () (_ BitVec 3))

--- a/test/regress/regress3/bv_to_int_check_bvsgt_bvlshr0_4bit.smt2.minimized.smt2
+++ b/test/regress/regress3/bv_to_int_check_bvsgt_bvlshr0_4bit.smt2.minimized.smt2
@@ -1,6 +1,5 @@
 ; COMMAND-LINE:  --solve-bv-as-int=bv
 ; COMMAND-LINE:  --solve-bv-as-int=sum
-; COMMAND-LINE:  --solve-bv-as-int=bitwise
 ; COMMAND-LINE:  --solve-bv-as-int=iand --iand-mode=sum
 ; COMMAND-LINE:  --solve-bv-as-int=iand --iand-mode=bitwise
 ; COMMAND-LINE:  --solve-bv-as-int=iand --iand-mode=value

--- a/test/regress/regress3/bv_to_int_check_ne_bvlshr0_4bit.smt2.minimized.smt2
+++ b/test/regress/regress3/bv_to_int_check_ne_bvlshr0_4bit.smt2.minimized.smt2
@@ -1,6 +1,5 @@
 ; COMMAND-LINE:  --solve-bv-as-int=bv --no-check-unsat-cores
 ; COMMAND-LINE:  --cegqi-all --full-saturate-quant --bvand-integer-granularity=1 --solve-bv-as-int=sum  --no-check-unsat-cores
-; COMMAND-LINE:  --cegqi-all --full-saturate-quant --bvand-integer-granularity=1 --solve-bv-as-int=bitwise  --no-check-unsat-cores
 ; EXPECT: unsat
 (set-logic BV)
 (declare-fun s () (_ BitVec 4))

--- a/test/regress/regress3/bv_to_int_input_mouser_detect.c.smt2.minimized.smt2
+++ b/test/regress/regress3/bv_to_int_input_mouser_detect.c.smt2.minimized.smt2
@@ -1,6 +1,5 @@
 ; COMMAND-LINE:  --solve-bv-as-int=bv  --no-check-models
 ; COMMAND-LINE:  --bvand-integer-granularity=1 --solve-bv-as-int=sum --full-saturate-quant --cegqi-all  --no-check-models
-; COMMAND-LINE:  --bvand-integer-granularity=1 --solve-bv-as-int=bitwise --full-saturate-quant --cegqi-all  --no-check-models
 ;EXPECT: sat
 (set-logic BV)
 (assert (exists ((c__detect__main__1__i_36_C (_ BitVec 32))) (bvslt ((_ sign_extend 32) c__detect__main__1__i_36_C) (_ bv0 64))))

--- a/test/regress/regress3/bv_to_int_quant1.smt2
+++ b/test/regress/regress3/bv_to_int_quant1.smt2
@@ -1,5 +1,4 @@
 ; COMMAND-LINE:  --cegqi-all --full-saturate-quant --bvand-integer-granularity=1 --solve-bv-as-int=sum  --no-check-unsat-cores
-; COMMAND-LINE:  --cegqi-all --full-saturate-quant --bvand-integer-granularity=1 --solve-bv-as-int=bitwise  --no-check-unsat-cores
 ; EXPECT: unsat
 (set-logic BV)
 (declare-fun s () (_ BitVec 4))

--- a/test/regress/regress3/bv_to_int_quant2.smt2
+++ b/test/regress/regress3/bv_to_int_quant2.smt2
@@ -1,5 +1,4 @@
 ; COMMAND-LINE: --cegqi-all --full-saturate-quant --solve-bv-as-int=sum --no-check-models
-; COMMAND-LINE: --cegqi-all --full-saturate-quant --solve-bv-as-int=bitwise --no-check-models
 ; COMMAND-LINE: --cegqi-all --full-saturate-quant --solve-bv-as-int=bv --no-check-models
 ; COMMAND-LINE: --cegqi-all --full-saturate-quant --solve-bv-as-int=iand --no-check-models
 ; EXPECT: sat


### PR DESCRIPTION
Removing `--solve-bv-as-int=bitwise` from quantifier benchmarks.